### PR TITLE
Fix inventory_upload to use providers-common

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "sources-api-client",         :git => "https://github.com/ManageIQ/sources-a
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
 gem "topological_inventory-core", :git => "https://github.com/ManageIQ/topological_inventory-core", :branch => "master"
 gem "topological_inventory-api-client", :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
+gem "topological_inventory-providers-common", :git => "https://github.com/ManageIQ/topological_inventory-providers-common", :branch => "master"
 
 group :development, :test do
   gem "rake"

--- a/lib/topological_inventory/sync/inventory_upload/parser/cfme.rb
+++ b/lib/topological_inventory/sync/inventory_upload/parser/cfme.rb
@@ -56,7 +56,6 @@ module TopologicalInventory
             TopologicalInventoryIngressApiClient::Host.new(
               :name        => host_data["name"],
               :hostname    => host_data["hostname"],
-              :ipaddress   => host_data["ipaddress"],
               :power_state => host_data["power_state"],
               :uid_ems     => host_data["uid_ems"],
               :source_ref  => host_data["ems_ref"],

--- a/lib/topological_inventory/sync/inventory_upload/payload.rb
+++ b/lib/topological_inventory/sync/inventory_upload/payload.rb
@@ -180,7 +180,7 @@ module TopologicalInventory
         end
 
         def ingress_api_sender
-          TopologicalInventoryIngressApiClient::SaveInventory::Saver.new(
+          TopologicalInventory::Providers::Common::SaveInventory::Saver.new(
             :client => ingress_api_client,
             :logger => logger
           )

--- a/lib/topological_inventory/sync/inventory_upload/processor_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload/processor_worker.rb
@@ -2,7 +2,7 @@ require "json"
 require "topological_inventory/sync/worker"
 require "topological_inventory/sync/inventory_upload/payload"
 require "topological_inventory-ingress_api-client"
-require "topological_inventory-ingress_api-client/save_inventory/saver"
+require "topological_inventory/providers/common/save_inventory/saver"
 
 module TopologicalInventory
   class Sync


### PR DESCRIPTION
Depends:

- [x] https://github.com/RedHatInsights/topological_inventory-core/pull/160
- [x] https://github.com/ManageIQ/topological_inventory-ingress_api/pull/73
- [x] https://github.com/RedHatInsights/topological_inventory-ingress_api-client-ruby/pull/60