### PR TITLE
Set is_org_admin for API calls to sources

### DIFF
--- a/lib/topological_inventory/sync/api_client.rb
+++ b/lib/topological_inventory/sync/api_client.rb
@@ -9,7 +9,14 @@ module TopologicalInventory
       {
         'x-rh-identity' =>
             Base64.strict_encode64(
-              JSON.dump('identity' => { 'account_number' => tenant })
+              JSON.dump(
+                'identity' => {
+                  'account_number' => tenant,
+                  'user'           => {
+                    'is_org_admin' => true
+                  }
+                }
+              )
             )
       }
     end

--- a/spec/topological_inventory/sync/sources_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/sources_sync_worker_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
   context "#initial_sync" do
     before do
       identity = Base64.strict_encode64(
-        JSON.dump({"identity" => {"account_number" => "topological_inventory-sources_sync"}}))
+        JSON.dump({"identity" => {"account_number" => "topological_inventory-sources_sync", "user" => {"is_org_admin" => true}}}))
       allow(RestClient).to receive(:get)
         .with("http://cloud.redhat.com:443/internal/v1.0/tenants", {"x-rh-identity"=> identity})
         .and_return("[{\"external_tenant\":\"12345\"}]")


### PR DESCRIPTION
We need to set the user.is_org_admin attribute for API calls to
sources-api otherwise a missing key will trigger an unauthorized error
even if the API call is readonly.