### PR TITLE
Bump core to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "optimist"
 
 gem "sources-api-client", "~> 1.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0"
-gem "topological_inventory-core", :git => "https://github.com/RedHatInsights/topological_inventory-core", :branch => "master"
+gem "topological_inventory-core", "~> 1.0.0"
 gem "topological_inventory-api-client", "~> 2.0"
 gem "topological_inventory-providers-common", "~> 0.1"
 


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-core/issues/190

Merged PRs can't affect production with incompatible code

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/189 **[ requires RubyGems release ]**