### PR TITLE
Bump core to 1.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rest-client",      ">= 1.8.0"
 
 gem "sources-api-client", "~> 1.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0", ">= 1.0.1"
-gem "topological_inventory-core", "~> 1.0.0"
+gem "topological_inventory-core", "~> 1.1.1"
 gem "topological_inventory-api-client", "~> 2.0"
 gem "topological_inventory-providers-common", "~> 0.1"
 


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-core/issues/191

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/188 **[ requires RubyGems release ]**