### PR TITLE
Update payload_id to request_id

### DIFF
--- a/lib/topological_inventory/sync/inventory_upload/processor_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload/processor_worker.rb
@@ -27,11 +27,11 @@ module TopologicalInventory
           return unless data["service"] == "topological-inventory"
 
           log_header = "account [#{data["account"]}] request_id [#{data["request_id"]}]"
-          logger.info("#{log_header}: Processing payload [#{data["payload_id"]}]...")
+          logger.info("#{log_header}: Processing payload [#{data["request_id"]}]...")
 
           Payload.load(data, &:process)
 
-          logger.info("#{log_header}: Processing payload [#{data["payload_id"]}]...Complete")
+          logger.info("#{log_header}: Processing payload [#{data["request_id"]}]...Complete")
         end
       end
     end

--- a/lib/topological_inventory/sync/inventory_upload/validator_worker.rb
+++ b/lib/topological_inventory/sync/inventory_upload/validator_worker.rb
@@ -23,10 +23,10 @@ module TopologicalInventory
         def perform(message)
           payload = JSON.parse(message.payload)
 
-          account, request_id, payload_id = payload.values_at("account", "request_id", "payload_id")
+          account, request_id = payload.values_at("account", "request_id")
           log_header = "account [#{account}] request_id [#{request_id}]"
 
-          logger.info("#{log_header}: Validating payload [#{payload_id}]...")
+          logger.info("#{log_header}: Validating payload [#{request_id}]...")
 
           valid = "failure"
           reason = nil
@@ -46,7 +46,7 @@ module TopologicalInventory
 
           payload["validation"] = valid
 
-          logger.info("#{log_header}: Validating payload [#{payload_id}]...Complete - #{payload["validation"]}#{reason ? ", #{reason}" : ""}")
+          logger.info("#{log_header}: Validating payload [#{request_id}]...Complete - #{payload["validation"]}#{reason ? ", #{reason}" : ""}")
 
           publish_validation(payload)
         end

--- a/spec/helpers/inventory_upload_helper.rb
+++ b/spec/helpers/inventory_upload_helper.rb
@@ -35,7 +35,7 @@ module InventoryUploadHelper
 
   def insights_upload_payload
     "{\"account\":\"12345\",\"rh_account\":\"12345\",\"principal\":\"54321\",\"request_id\":\"52df9f748eabcfeb\",\
-    \"payload_id\":\"52df9f748eabcfeb\",\"size\":458,\"service\":\"topological-inventory\",\"category\":\"something\",\
+    \"request_id\":\"52df9f748eabcfeb\",\"size\":458,\"service\":\"topological-inventory\",\"category\":\"something\",\
     \"b64_identity\":\"eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTIzNDUiLCAiaW50ZXJuYWwiOiB7Im9yZ19pZCI6ICI1NDMyMSJ9fX0=\",\
     \"url\":\"/tmp/upload/schema.tar.gz\"}"
   end

--- a/spec/topological_inventory/sync/inventory_upload/validator_worker_spec.rb
+++ b/spec/topological_inventory/sync/inventory_upload/validator_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TopologicalInventory::Sync::InventoryUpload::ValidatorWorker do
     let(:file_path) { "/tmp/uploads/insights-upload-perm-test/#{request_id}" }
     let(:payload) do
       "{\"account\":\"12345\",\"rh_account\":\"12345\",\"principal\":\"54321\",\"request_id\":\"52df9f748eabcfeb\",\
-      \"payload_id\":\"52df9f748eabcfeb\",\"size\":458,\"service\":\"topological-inventory\",\"category\":\"something\",\
+      \"request_id\":\"52df9f748eabcfeb\",\"size\":458,\"service\":\"topological-inventory\",\"category\":\"something\",\
       \"b64_identity\":\"eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMTIzNDUiLCAiaW50ZXJuYWwiOiB7Im9yZ19pZCI6ICI1NDMyMSJ9fX0=\",\
       \"url\":\"/tmp/upload/schema.tar.gz\"}"
     end


### PR DESCRIPTION
The Payload Tracker is transitioning to using the new "request_id" terminology instead of the legacy "payload_id." This renames that field.