### PR TITLE
Switch host-inventory-sync to post HBI to kafka rather than HTTP

### DIFF
--- a/lib/topological_inventory/sync/configuration.rb
+++ b/lib/topological_inventory/sync/configuration.rb
@@ -1,0 +1,46 @@
+module TopologicalInventory
+  class Sync
+    class Configuration
+      # Kafka message auto-ack (default false)
+      attr_accessor :queue_auto_ack
+      # Kafka host name
+      attr_accessor :queue_host
+      # Kafka topic max bytes received in one response
+      attr_accessor :queue_max_bytes
+      # Kafka topic grouping (if nil, all subscribes receives all messages)
+      attr_accessor :queue_persist_ref
+      # Kafka port
+      attr_accessor :queue_port
+      # Kafka topic name for cloud receptor controller's responses
+      attr_accessor :queue_topic
+
+      # Timeout for how long successful request waits for response
+      attr_accessor :response_timeout
+      # Interval between timeout checks
+      attr_accessor :response_timeout_poll_time
+
+      def initialize(queue_host: nil, queue_port: nil)
+        @pre_shared_key    = nil
+        @queue_auto_ack    = false
+        @queue_host        = queue_host
+        @queue_max_bytes   = nil
+        @queue_persist_ref = ENV['HOSTNAME']
+        @queue_port        = queue_port
+        @queue_topic       = 'platform.inventory.events'
+
+        @response_timeout           = 1.hour
+        @response_timeout_poll_time = 1.hour
+
+        yield(self) if block_given?
+      end
+
+      def self.default
+        @default ||= new
+      end
+
+      def configure
+        yield(self) if block_given?
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/sync/host_inventory_response_worker.rb
+++ b/lib/topological_inventory/sync/host_inventory_response_worker.rb
@@ -1,0 +1,161 @@
+require "concurrent"
+require "stringio"
+
+module TopologicalInventory
+  class Sync
+    class ResponseWorker
+      attr_reader :started
+      alias started? started
+
+      def initialize(config, logger)
+        self.config              = config
+        self.lock                = Mutex.new
+        self.timeout_lock        = Mutex.new
+        self.logger              = logger
+        self.started             = Concurrent::AtomicBoolean.new(false)
+        self.registered_messages = Concurrent::Map.new
+        self.workers             = {}
+      end
+
+      # Start listening on Kafka
+      def start
+        lock.synchronize do
+          return if started.value
+
+          started.value = true
+          workers[:maintenance] = Thread.new { check_timeouts while started.value }
+          workers[:listener]    = Thread.new { listen while started.value }
+        end
+      end
+
+      # Stop listener
+      def stop
+        lock.synchronize do
+          return unless started.value
+
+          started.value = false
+          workers[:listener]&.terminate
+          workers[:maintenance]&.join
+        end
+      end
+
+      def register_message(external_id, source_id)
+        registered_messages[external_id] = {
+          :source_id  => source_id,
+          :created_at => Time.now.utc
+        }
+      end
+
+      private
+
+      attr_accessor :config, :lock, :timeout_lock, :logger, :workers, :registered_messages
+      attr_writer :started
+
+      def listen
+        # Open a connection to the messaging service
+        client = ManageIQ::Messaging::Client.open(default_messaging_opts)
+
+        logger.info("Topological Inventory Sync Response worker started...")
+        client.subscribe_topic(queue_opts) do |message|
+          process_message(message)
+        end
+      rescue => err
+        logger.error("Exception in kafka listener: #{err}\n#{err.backtrace.join("\n")}")
+      ensure
+        client&.close
+      end
+
+      def process_message(message)
+        response = JSON.parse(message.payload)
+
+        return unless response['type'] == 'created'
+
+        host           = response['host'] if response
+        external_id    = host['external_id'] if host
+        registered_msg = registered_messages[external_id] if external_id
+        source_id      = registered_msg[:source_id] if registered_msg
+
+        if source_id.nil?
+          logger.debug("ResponseWorker: There is no registered request for '#{host['display_name']}' VM with external_id:'#{external_id}'")
+          return
+        end
+
+        new_vm = TopologicalInventoryIngressApiClient::Vm.new(
+          :source_ref          => external_id,
+          :host_inventory_uuid => host["id"]
+        )
+
+        save_vms_to_topological_inventory([new_vm], source_id)
+        registered_messages.delete(external_id)
+        logger.info("Topological Inventory has been updated with '#{host['display_name']}' VM (source:'#{source_id}').")
+      rescue => e
+        logger.error("#{e.message} -  #{e.backtrace.join("\n")}")
+      end
+
+      def check_timeouts(threshold = config.response_timeout)
+        expired = []
+        #
+        # STEP 1 Collect expired messages
+        #
+        registered_messages.each do |external_id, msg|
+          timeout_lock.synchronize do
+            if msg[:created_at] < Time.now.utc - threshold
+              expired << external_id
+            end
+          end
+        end
+
+        #
+        # STEP 2 Remove expired messages, send timeout callbacks
+        #
+        expired.each do |external_id|
+          registered_messages.delete(external_id)
+          logger.debug("ResponseWorker: Registrated request for external_id = '#{external_id}' has reached the timeout and it has been removed.")
+        end
+
+        sleep(config.response_timeout_poll_time)
+      rescue => err
+        logger.error("Exception in maintenance worker: #{err}\n#{err.backtrace.join("\n")}")
+      end
+
+      def save_vms_to_topological_inventory(topological_inventory_vms, source)
+        # TODO(lsmola) if VM will have subcollections, this will need to send just partial data, otherwise all subcollections
+        # would get deleted. Alternative is having another endpoint than :vms, for doing update only operation. Partial data
+        # are not supported without timestamp for update (at least for now), since that is just being added to skeletal
+        # precreate.
+        TopologicalInventory::Providers::Common::SaveInventory::Saver.new(:client => ingress_api_client, :logger => logger).save(
+          :inventory => TopologicalInventoryIngressApiClient::Inventory.new(
+            :schema                     => TopologicalInventoryIngressApiClient::Schema.new(:name => "Default"),
+            :source                     => source,
+            :collections                => [
+              TopologicalInventoryIngressApiClient::InventoryCollection.new(:name => :vms, :data => topological_inventory_vms)
+            ],
+            :refresh_state_part_sent_at => Time.now.utc
+          )
+        )
+      end
+
+      def ingress_api_client
+        TopologicalInventoryIngressApiClient::DefaultApi.new
+      end
+
+      # No persist_ref here, because all instances (pods) needs to receive kafka message
+      def queue_opts
+        opts               = {:service => config.queue_topic}
+        opts[:auto_ack]    = config.queue_auto_ack    unless config.queue_auto_ack.nil?
+        opts[:max_bytes]   = config.queue_max_bytes   if config.queue_max_bytes
+        opts[:persist_ref] = config.queue_persist_ref if config.queue_persist_ref
+        opts
+      end
+
+      def default_messaging_opts
+        {
+          :host       => config.queue_host,
+          :port       => config.queue_port,
+          :protocol   => :Kafka,
+          :client_ref => ENV['HOSTNAME'], # A reference string to identify the client
+        }
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/sync/host_inventory_response_worker_spec.rb
+++ b/spec/topological_inventory/sync/host_inventory_response_worker_spec.rb
@@ -1,0 +1,142 @@
+require 'topological_inventory/sync/host_inventory_response_worker'
+require 'topological_inventory-ingress_api-client'
+
+RSpec.describe TopologicalInventory::Sync::ResponseWorker do
+  let(:logger)      { double('logger') }
+  let(:config)      { double('config') }
+  let(:vm_name)     { 'vm-sync-test' }
+  let(:source_id)   { 'source_id' }
+  let(:external_id) do
+    '/subscriptions/d8dab060-0000-0000-82d7-afc3ff5c7b06/resourceGroups' \
+    "/test/providers/Microsoft.Compute/virtualMachines/#{vm_name}"
+  end
+
+  subject { described_class.new(config, logger) }
+
+  describe '#register_message' do
+    it 'saves external_id and related source_id' do
+      subject.register_message(external_id, source_id)
+
+      expect(subject.send(:registered_messages)[external_id][:source_id]).to eq(source_id)
+    end
+  end
+
+  describe '#process_message' do
+    let(:msg)         { Message.new(msg_type, vm_name, external_id, vm_id) }
+    let(:msg_type)    { 'created' }
+    let(:vm_id)       { 'd45bc3e0-0000-0000-0000-9dec543acad4' }
+
+    let(:new_vm) do
+      TopologicalInventoryIngressApiClient::Vm.new(
+        :source_ref          => external_id,
+        :host_inventory_uuid => vm_id
+      )
+    end
+
+    it 'updates Topological Inventory' do
+      subject.register_message(external_id, source_id)
+
+      expect(subject).to receive(:save_vms_to_topological_inventory).with([new_vm], source_id)
+      expect(logger).to receive(:info).with("Topological Inventory has been updated with '#{vm_name}' VM (source:'#{source_id}').")
+
+      subject.send(:process_message, msg)
+    end
+
+    it 'skips without related source' do
+      expect(logger).to receive(:debug).with(
+        "ResponseWorker: There is no registered request for '#{vm_name}' VM with external_id:'#{external_id}'"
+      )
+
+      subject.send(:process_message, msg)
+    end
+
+    it "skips for any other type than 'create'" do
+      msg.msg_type = 'updated'
+      expect(subject).to_not receive(:save_vms_to_topological_inventory)
+
+      subject.send(:process_message, msg)
+    end
+
+    it 'does not process message without payload' do
+      msg_payload = 'Hello World!'
+      expect(msg).to receive(:payload).and_return(msg_payload)
+      expect(logger).to_not receive(:info)
+      expect(logger).to receive(:error).with(
+        /.*(unexpected token at 'Hello World!').*/
+      )
+
+      subject.send(:process_message, msg)
+    end
+  end
+
+  describe '#check_timeouts' do
+    before do
+      allow(config).to receive(:response_timeout).and_return(2.minutes)
+      allow(config).to receive(:response_timeout_poll_time).and_return(0.seconds)
+    end
+
+    it 'removes expired sources' do
+      id     = external_id
+      source = source_id
+      subject.instance_eval do
+        registered_messages[id] = {:source_id => source, :created_at => Time.now.utc - 1.hour}
+      end
+
+      expect(logger).to receive(:debug).with(
+        "ResponseWorker: Registrated request for external_id = '#{id}' has reached the timeout and it has been removed."
+      )
+
+      subject.send(:check_timeouts)
+      expect(subject.send(:registered_messages).size).to eq(0)
+    end
+
+    it 'does not remove valid sources' do
+      subject.register_message(external_id, source_id)
+      subject.send(:check_timeouts)
+      expect(subject.send(:registered_messages)[external_id][:source_id]).to eq(source_id)
+    end
+  end
+end
+
+class Message
+  attr_accessor :msg_type, :vm_name, :external_id, :vm_id
+
+  def initialize(msg_type = 'created', vm_name = 'vm', external_id = 'external_id', vm_id = 'vm_id')
+    self.msg_type    = msg_type
+    self.vm_name     = vm_name
+    self.external_id = external_id
+    self.vm_id       = vm_id
+  end
+
+  def payload
+    {
+      'metadata'          => {'request_id' => '-1'},
+      'type'              => msg_type,
+      'host'              => {
+        'insights_id'             => nil,
+        'ip_addresses'            => nil,
+        'id'                      => vm_id,
+        'culled_timestamp'        => '2020-08-26T14:00:56+00:00',
+        'account'                 => '6081020',
+        'tags'                    => [],
+        'display_name'            => vm_name,
+        'created'                 => '2020-08-11T12:26:05.696381+00:00',
+        'satellite_id'            => nil,
+        'mac_addresses'           => ['00-22-48-23-D4-04'],
+        'stale_warning_timestamp' => '2020-08-19T14:00:56+00:00',
+        'stale_timestamp'         => '2020-08-12T14:00:56+00:00',
+        'ansible_host'            => nil,
+        'subscription_manager_id' => nil,
+        'rhel_machine_id'         => nil,
+        'external_id'             => external_id,
+        'reporter'                => 'topological-inventory',
+        'updated'                 => '2020-08-11T14:00:56.515374+00:00',
+        'system_profile'          => {},
+        'fqdn'                    => nil,
+        'bios_uuid'               => nil
+      },
+      'platform_metadata' => {},
+      'timestamp'         => '2020-08-11T14:00:56.521853+00:00'
+    }.to_json
+  end
+end

--- a/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/host_inventory_sync_worker_spec.rb
@@ -120,45 +120,21 @@ RSpec.describe TopologicalInventory::Sync::HostInventorySyncWorker do
       expect(host_inventory_sync_service).to(
         receive(:create_host_inventory_hosts)
           .with(*make_host_arg(mac_addresses_1, "vm1"))
-          .and_return(
-            mock_body({"data" => [{"host" => {"id" => "host_uuid_1"}}]})
-          )
       )
 
       expect(host_inventory_sync_service).to(
         receive(:create_host_inventory_hosts)
           .with(*make_host_arg(mac_addresses_2, "vm2"))
-          .and_return(
-            mock_body({"data" => [{"host" => {"id" => "host_uuid_2"}}]})
-          )
       )
 
       expect(host_inventory_sync_service).to(
         receive(:create_host_inventory_hosts)
           .with(*make_host_arg(mac_addresses_3, "vm3"))
-          .and_return(
-            mock_body({"data" => [{"host" => {"id" => "host_uuid_3"}}]})
-          )
       )
 
       expect(host_inventory_sync_service).to(
         receive(:create_host_inventory_hosts)
           .with(*make_host_arg([], "vm4"))
-          .and_return(
-            mock_body({"data" => [{"host" => {"id" => "host_uuid_4"}}]})
-          )
-      )
-
-      expect(host_inventory_sync_service).to(
-        receive(:save_vms_to_topological_inventory).with(
-          [
-            TopologicalInventoryIngressApiClient::Vm.new(:source_ref => "vm1", :host_inventory_uuid => "host_uuid_1"),
-            TopologicalInventoryIngressApiClient::Vm.new(:source_ref => "vm2", :host_inventory_uuid => "host_uuid_2"),
-            TopologicalInventoryIngressApiClient::Vm.new(:source_ref => "vm3", :host_inventory_uuid => "host_uuid_3"),
-            TopologicalInventoryIngressApiClient::Vm.new(:source_ref => "vm4", :host_inventory_uuid => "host_uuid_4"),
-          ],
-          source
-        )
       )
 
       host_inventory_sync_service.send(:perform, message)
@@ -203,15 +179,15 @@ RSpec.describe TopologicalInventory::Sync::HostInventorySyncWorker do
 
   def make_host_arg(mac_addresses, source_ref)
     [
-      "eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6ImV4dGVybmFsX3RlbmFu\ndF91dWlkIn19\n",
       {
         :mac_addresses   => mac_addresses,
         :account         => account_number,
         :external_id     => source_ref,
         :display_name    => nil,
         :reporter        => "topological-inventory",
-        :stale_timestamp => Time.now.utc + 86400
-      }
+        :stale_timestamp => (Time.now.utc + 86_400).to_datetime
+      },
+      source
     ]
   end
 


### PR DESCRIPTION
Description
---
Moving the host-inventory VM creation call from HTTP to Kafka. 

This PR is based on https://projects.engineering.redhat.com/browse/TPINVTRY-874. 

Testing
---
### Changes I made for being able to work locally:
1) `insights-host-inventory/app/config.py:44` -  kafka port change
    * before: `self.bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:29092")`
    * after:   `self.bootstrap_servers = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")`
2) `insights-host-inventory/app/config.py:44` - response topic change
    * There are three types of events HBI produces: `created`, `updated` and `delete`. All the events are sent as kafka messages to the `platform.inventory.events` kafka topic as you can find in the [documentation](https://platform-docs.cloud.paas.psi.redhat.com/backend/inventory.html#event-interface)
    * Since my local environment were posting these messages only into the `KAFKA_HOST_EGRESS_TOPIC`, I changed the topic.
    * before: `self.host_egress_topic = os.environ.get("KAFKA_HOST_EGRESS_TOPIC", "platform.inventory.events")`
    * after:    `self.host_egress_topic = os.environ.get("KAFKA_HOST_EGRESS_TOPIC", "platform.inventory.host-egress")`

### Testing steps:
1) use the `start.sh` script from scripts to start up most of the required things.
2) start some collector(I was working with azure) and create a new VM on this platform. (`services/azure-collector.sh`)
3) start `services/host-inventory-sync` script to run the topological_inventory-sync repo
4) start `insights-host-inventory` repo
  4.1) `pipenv shell`
  4.2) `make run_inv_mq_service`

Your sync repo now should be getting messages about a new VM from persistor. It should process these messages, save the related source_id into the response worker(`register_message` method) and send the create request into the insights-host-inventory repo. Then the response worker should get a message about result.

### sync log:
 NOTE: console output has been filtered and logs with no VMs are skipped
![Screenshot from 2020-08-19 13-21-40](https://user-images.githubusercontent.com/19405716/90629172-2e7c8f00-e21f-11ea-81d1-656136e7621b.png)

### insights-host-inventory log:
![Screenshot from 2020-08-19 13-21-21](https://user-images.githubusercontent.com/19405716/90629161-2a507180-e21f-11ea-982c-ca1c9ed2e855.png)
