### PR TITLE
Sources Sync: Added pagination to api calls

### DIFF
--- a/lib/topological_inventory/sync/iterator.rb
+++ b/lib/topological_inventory/sync/iterator.rb
@@ -1,0 +1,29 @@
+module TopologicalInventory
+  class Sync
+    class Iterator
+      attr_reader :block, :limit, :resource_id
+
+      def initialize(block, limit: 100, resource_id: nil)
+        @block = block
+        @limit = limit
+        @resource_id = resource_id
+      end
+
+      def each
+        offset = 0
+
+        loop do
+          collection = resource_id.nil? ? block.call(limit, offset) : block.call(resource_id, limit, offset)
+          %i[data meta].each do |method|
+            raise "Provided block expects Sources API Client response" unless collection.respond_to?(method)
+          end
+          break if collection.data.blank?
+
+          collection.data.each { |record| yield record }
+          offset += limit
+          break if offset >= collection.meta.count.to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/sync/iterator.rb
+++ b/lib/topological_inventory/sync/iterator.rb
@@ -11,17 +11,17 @@ module TopologicalInventory
 
       def each
         offset = 0
+        finished = false
 
-        loop do
+        until finished
           collection = resource_id.nil? ? block.call(limit, offset) : block.call(resource_id, limit, offset)
-          %i[data meta].each do |method|
-            raise "Provided block expects Sources API Client response" unless collection.respond_to?(method)
-          end
+          %i[data meta].each { |method| raise "Sources API Client response expected" unless collection.respond_to?(method) }
           break if collection.data.blank?
 
           collection.data.each { |record| yield record }
           offset += limit
-          break if offset >= collection.meta.count.to_i
+
+          finished = true if offset >= collection.meta.count.to_i
         end
       end
     end

--- a/lib/topological_inventory/sync/sources_sync_worker.rb
+++ b/lib/topological_inventory/sync/sources_sync_worker.rb
@@ -1,5 +1,6 @@
 require "rest-client"
 require "topological_inventory/sync/worker"
+require "topological_inventory/sync/iterator"
 require "more_core_extensions/core_ext/module/cache_with_timeout"
 require "uri"
 
@@ -27,17 +28,39 @@ module TopologicalInventory
         "topological-inventory-sync-sources"
       end
 
+      def self.application_types(tenant)
+        block = lambda { |limit, offset| sources_api_client(tenant).list_application_types(:limit => limit, :offset => offset) }
+        TopologicalInventory::Sync::Iterator.new(block)
+      end
+
+      def applications(tenant)
+        block = lambda { |limit, offset| sources_api_client(tenant).list_applications(:limit => limit, :offset => offset) }
+        TopologicalInventory::Sync::Iterator.new(block)
+      end
+
+      def sources(tenant)
+        block = lambda { |limit, offset| sources_api_client(tenant).list_sources(:limit => limit, :offset => offset) }
+        TopologicalInventory::Sync::Iterator.new(block)
+      end
+
+      def source_applications(tenant, source_id)
+        block = lambda { |resource_id, limit, offset| sources_api_client(tenant).list_source_applications(resource_id, :limit => limit, :offset => offset) }
+        TopologicalInventory::Sync::Iterator.new(block, :resource_id => source_id.to_s)
+      end
+
       def initial_sync
         sources_by_uid       = {}
         tenant_by_source_uid = {}
 
         tenants.each do |tenant|
-          applications            = sources_api_client(tenant).list_applications.data
-          supported_applications  = applications.select { |app| supported_application_type_ids.include?(app.application_type_id) }
+          supported_applications = []
+          applications(tenant).each do |app|
+            supported_applications << app if supported_application_type_ids.include?(app.application_type_id)
+          end
 
           supported_applications_by_source_id = supported_applications.group_by(&:source_id)
 
-          sources_api_client(tenant).list_sources.data.each do |source|
+          sources(tenant).each do |source|
             next unless supported_applications_by_source_id[source.id].present?
             sources_by_uid[source.uid]       = source
             tenant_by_source_uid[source.uid] = tenant
@@ -87,7 +110,8 @@ module TopologicalInventory
           end
         when "Application.destroy"
           source_id = payload["source_id"]
-          source_apps = sources_api_client(tenant).list_source_applications(source_id.to_s).data
+          source_apps = []
+          source_applications(tenant, source_id.to_s).each { |source_app| source_apps << source_app }
           source_application_type_ids = source_apps.collect(&:application_type_id).uniq
           # Delete Source if there is no remaining supported application
           if (source_application_type_ids & supported_application_type_ids).blank?
@@ -104,13 +128,15 @@ module TopologicalInventory
         @tenants_by_external_tenant[external_tenant] ||= Tenant.find_or_create_by(:external_tenant => external_tenant)
       end
 
+      # TODO: Pagination not available in Sources Internal API!
       def tenants
         response = RestClient.get(internal_tenants_url, identity_headers("topological_inventory-sources_sync"))
         JSON.parse(response).map { |tenant| tenant["external_tenant"] }
       end
 
       cache_with_timeout(:supported_application_type_ids) do
-        application_types = sources_api_client("system_orchestrator").list_application_types.data
+        application_types = []
+        application_types("system_orchestrator").each { |app_type| application_types << app_type }
         application_types.select { |application_type| needs_topology?(application_type) }.map(&:id)
       end
 

--- a/spec/topological_inventory/sync/iterator_spec.rb
+++ b/spec/topological_inventory/sync/iterator_spec.rb
@@ -1,0 +1,101 @@
+require "topological_inventory/sync"
+require "sources-api-client"
+
+RSpec.describe TopologicalInventory::Sync::Iterator do
+  let(:app_types_count) { 4 }
+  let(:app_types) do
+    data = []
+    app_types_count.times do |i|
+      data << SourcesApiClient::ApplicationType.new(
+        :name => "insights/platform/app-#{i}",
+        :dependent_applications => [],
+        :id => i.to_s
+      )
+    end
+    data
+  end
+
+  let(:sources_api_client) { double("SourcesApiClient::Default") }
+
+  describe "#each" do
+    context "without resource" do
+      it "calls the block and yields returned data" do
+        response = SourcesApiClient::ApplicationTypesCollection.new(
+          :data => [app_types[0]],
+          :meta => SourcesApiClient::CollectionMetadata.new(:count => 1)
+        )
+        expect(sources_api_client).to receive(:list_application_types).and_return(response)
+
+        iterator = described_class.new(lambda {|_, _| sources_api_client.list_application_types})
+
+        cnt = 0
+        iterator.each do |data|
+          expect(data).to eq(app_types[0])
+          cnt += 1
+        end
+        expect(cnt).to eq(1)
+      end
+
+      (1..5).each do |limit|
+        it "calls the block with pagination (limit: #{limit})" do
+          offset = 0
+          while offset < app_types_count do
+            low, high = offset, [offset + limit - 1, app_types_count].min
+            response = SourcesApiClient::ApplicationTypesCollection.new(
+              :data => app_types[low..high],
+              :meta => SourcesApiClient::CollectionMetadata.new(:count => app_types_count)
+            )
+            expect(sources_api_client).to(receive(:list_application_types)
+                                            .with(:limit => limit, :offset => offset)
+                                            .and_return(response))
+            offset += limit
+          end
+          block = lambda { |l, o| sources_api_client.list_application_types(:limit => l, :offset => o)}
+          iterator = described_class.new(block, :limit => limit)
+
+          cnt = 0
+          iterator.each do |data|
+            expect(data).to eq(app_types[cnt])
+            cnt += 1
+          end
+
+          expect(cnt).to eq(app_types_count)
+        end
+      end
+
+      it "raises an exception if response isn't compatible with api client" do
+        response = {:data => app_types}
+        expect(sources_api_client).to receive(:unexpected_request).and_return(response)
+
+        iterator = described_class.new(lambda {|_, _| sources_api_client.unexpected_request})
+        msg      = "Provided block expects Sources API Client response"
+        expect { iterator.each { |_| expect("It shouldn't be here").to be_falsey } }.to raise_exception(msg)
+      end
+    end
+
+    context "with resource" do
+      let(:application) { SourcesApiClient::Application.new(:id => '1', :application_type_id => '1', :source_id => '1')}
+
+      it "calls the block with 3 parameters" do
+        source_id = '10'
+        response = SourcesApiClient::ApplicationsCollection.new(
+          :data => [application],
+          :meta => SourcesApiClient::CollectionMetadata.new(:count => 1)
+        )
+        expect(sources_api_client).to(receive(:list_source_applications)
+                                        .with(source_id, :limit => 1, :offset => 0)
+                                        .and_return(response))
+
+        block = lambda { |src_id, l, o| sources_api_client.list_source_applications(src_id, :limit => l, :offset => o)}
+        iterator = described_class.new(block, :limit => 1, :resource_id => source_id)
+
+        cnt = 0
+        iterator.each do |data|
+          expect(data).to eq(application)
+          cnt += 1
+        end
+        expect(cnt).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/topological_inventory/sync/sources_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/sources_sync_worker_spec.rb
@@ -38,9 +38,10 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
   context "#initial_sync" do
     before do
       identity = Base64.strict_encode64(
-        JSON.dump({"identity" => {"account_number" => "topological_inventory-sources_sync", "user" => {"is_org_admin" => true}}}))
+        JSON.dump("identity" => {"account_number" => "topological_inventory-sources_sync", "user" => {"is_org_admin" => true}})
+      )
       allow(RestClient).to receive(:get)
-        .with("http://cloud.redhat.com:443/internal/v1.0/tenants", {"x-rh-identity"=> identity})
+        .with("http://cloud.redhat.com:443/internal/v1.0/tenants", "x-rh-identity"=> identity)
         .and_return("[{\"external_tenant\":\"12345\"}]")
 
       allow(sources_api_client).to receive(:list_applications).and_return(
@@ -80,7 +81,7 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
   context "#perform" do
     let(:message)         { ManageIQ::Messaging::ReceivedMessage.new(nil, event, payload, headers, nil, nil) }
     let(:external_tenant) { SecureRandom.uuid }
-    let(:x_rh_identity)   { Base64.strict_encode64(JSON.dump({"identity" => {"account_number" => external_tenant}})) }
+    let(:x_rh_identity)   { Base64.strict_encode64(JSON.dump("identity" => {"account_number" => external_tenant})) }
     let(:headers)         { {"x-rh-identity" => x_rh_identity, "encoding" => "json"} }
 
     context "Application create event" do
@@ -148,9 +149,11 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
     context "source destroy event" do
       let(:tenant) { Tenant.find_or_create_by(:external_tenant => external_tenant) }
       let!(:source) { Source.create!(:tenant => tenant, :uid => SecureRandom.uuid) }
-      let(:applications_collection) { SourcesApiClient::ApplicationsCollection.new(:data  => [],
-                                                                                   :links => {},
-                                                                                   :meta  => SourcesApiClient::CollectionMetadata.new(:count => 0)) }
+      let(:applications_collection) do
+        SourcesApiClient::ApplicationsCollection.new(:data  => [],
+                                                     :links => {},
+                                                     :meta  => SourcesApiClient::CollectionMetadata.new(:count => 0))
+      end
 
       before do
         allow(sources_api_client).to receive(:list_source_applications).and_return(applications_collection)
@@ -185,12 +188,13 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
               :data  => [
                 SourcesApiClient::Application.new(
                   :application_type_id => '2',
-                  :id => '1',
-                  :source_id => source.id.to_s
+                  :id                  => '1',
+                  :source_id           => source.id.to_s
                 )
               ],
               :links => {},
-              :meta  => SourcesApiClient::CollectionMetadata.new(:count => 1))
+              :meta  => SourcesApiClient::CollectionMetadata.new(:count => 1)
+            )
           end
 
           it "deletes the source" do
@@ -204,12 +208,13 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
               :data  => [
                 SourcesApiClient::Application.new(
                   :application_type_id => '1',
-                  :id => '1',
-                  :source_id => source.id.to_s
+                  :id                  => '1',
+                  :source_id           => source.id.to_s
                 )
               ],
               :links => {},
-              :meta  => SourcesApiClient::CollectionMetadata.new(:count => 1))
+              :meta  => SourcesApiClient::CollectionMetadata.new(:count => 1)
+            )
           end
 
           it "doesn't delete the source" do

--- a/spec/topological_inventory/sync/sources_sync_worker_spec.rb
+++ b/spec/topological_inventory/sync/sources_sync_worker_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
             :id                     => "3"
           )
         ],
-        :links => {}
+        :links => {},
+        :meta  => SourcesApiClient::CollectionMetadata.new(:count => 3)
       )
     )
 
@@ -43,11 +44,15 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
         .and_return("[{\"external_tenant\":\"12345\"}]")
 
       allow(sources_api_client).to receive(:list_applications).and_return(
-        SourcesApiClient::ApplicationsCollection.new(:data => applications, :links => {})
+        SourcesApiClient::ApplicationsCollection.new(:data  => applications,
+                                                     :links => {},
+                                                     :meta  => SourcesApiClient::CollectionMetadata.new(:count => applications.size))
       )
 
       allow(sources_api_client).to receive(:list_sources).and_return(
-        SourcesApiClient::ApplicationsCollection.new(:data => sources, :links => {})
+        SourcesApiClient::ApplicationsCollection.new(:data  => sources,
+                                                     :links => {},
+                                                     :meta  => SourcesApiClient::CollectionMetadata.new(:count => sources.size))
       )
     end
 
@@ -143,7 +148,9 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
     context "source destroy event" do
       let(:tenant) { Tenant.find_or_create_by(:external_tenant => external_tenant) }
       let!(:source) { Source.create!(:tenant => tenant, :uid => SecureRandom.uuid) }
-      let(:applications_collection) { SourcesApiClient::ApplicationsCollection.new(:data => [], :links => {}) }
+      let(:applications_collection) { SourcesApiClient::ApplicationsCollection.new(:data  => [],
+                                                                                   :links => {},
+                                                                                   :meta  => SourcesApiClient::CollectionMetadata.new(:count => 0)) }
 
       before do
         allow(sources_api_client).to receive(:list_source_applications).and_return(applications_collection)
@@ -179,11 +186,11 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
                 SourcesApiClient::Application.new(
                   :application_type_id => '2',
                   :id => '1',
-                  :source_id => source.id.to_s,
-                  :tenant => tenant.external_tenant
+                  :source_id => source.id.to_s
                 )
               ],
-              :links => {})
+              :links => {},
+              :meta  => SourcesApiClient::CollectionMetadata.new(:count => 1))
           end
 
           it "deletes the source" do
@@ -198,11 +205,11 @@ RSpec.describe TopologicalInventory::Sync::SourcesSyncWorker do
                 SourcesApiClient::Application.new(
                   :application_type_id => '1',
                   :id => '1',
-                  :source_id => source.id.to_s,
-                  :tenant => tenant.external_tenant
+                  :source_id => source.id.to_s
                 )
               ],
-              :links => {})
+              :links => {},
+              :meta  => SourcesApiClient::CollectionMetadata.new(:count => 1))
           end
 
           it "doesn't delete the source" do


### PR DESCRIPTION
Initial sync is able to manage only first 100 (default limit) sources of each tenant.
This PR adds Iterator for pagination

---

[TPINVTRY-1061](https://projects.engineering.redhat.com/browse/TPINVTRY-1061)