### PR TITLE
Pin CloudWatchLogger to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem "cloudwatchlogger", "~> 0.2"
+gem "cloudwatchlogger", "~> 0.2.1"
 gem "http",             "~> 4.1.0", :require => false
 gem "json-stream",      "~> 0.2.0", :require => false
 gem "manageiq-loggers", "~> 0.4.0", ">= 0.4.2"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/70

CloudWatchLogger 0.3.0 is not compatible