### PR TITLE
Sources Sync Metrics fix

### DIFF
--- a/lib/topological_inventory/sync/metrics/sources_sync.rb
+++ b/lib/topological_inventory/sync/metrics/sources_sync.rb
@@ -4,8 +4,6 @@ module TopologicalInventory
   class Sync
     class Metrics
       class SourcesSync < TopologicalInventory::Sync::Metrics
-        private
-
         def source_created(cnt = 1)
           @sources_created_counter&.observe(cnt)
         end


### PR DESCRIPTION
Fixes #72 

There is `private` in metrics class, IDK how it should pass through tests, anyway QA pods are failing

---

[RHCLOUD-9939](https://issues.redhat.com/browse/RHCLOUD-9939)