### PR TITLE
Update travis URL in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TopologicalInventory::Sync
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-sync.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-sync)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-sync.svg?branch=master)](https://travis-ci.com/RedHatInsights/topological_inventory-sync)
 [![Maintainability](https://api.codeclimate.com/v1/badges/e121aded15a4a4a42153/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-sync/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/e121aded15a4a4a42153/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-sync/test_coverage)
 [![security](https://hakiri.io/github/RedHatInsights/topological_inventory-sync/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-sync/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.