### PR TITLE
Remove unrecognized group_ref from messaging client

### DIFF
--- a/lib/topological_inventory/sync/worker.rb
+++ b/lib/topological_inventory/sync/worker.rb
@@ -68,7 +68,6 @@ module TopologicalInventory
           :protocol   => :Kafka,
           :host       => messaging_host,
           :port       => messaging_port,
-          :group_ref  => "topological-inventory-sync-#{queue_name}",
           :client_ref => "topological-inventory-sync-#{queue_name}"
         }
       end


### PR DESCRIPTION
`group_ref` in messaging_client configuration is useless.

Moreover it started to crash on localhost with:
```
/home/mslemr/.rvm/gems/ruby-2.6.6@tp-inv/gems/rdkafka-0.8.0/lib/rdkafka/config.rb:173:in `block (2 levels) in native_config': No such configuration property: "group_ref" (Rdkafka::Config::ConfigError)
```

Also present in (not all) other repos