### PR TITLE
Sources Sync: Omit 404 errors

### DIFF
--- a/lib/topological_inventory/sync/worker.rb
+++ b/lib/topological_inventory/sync/worker.rb
@@ -29,8 +29,12 @@ module TopologicalInventory
           begin
             perform(message)
           rescue => err
-            metrics&.record_error(:event_sync)
-            logger.error("Event sync: #{err.message}\n#{err.backtrace.join("\n")}")
+            # i.e. 404 can be raised by cascade delete of Source with Application.destroy event
+            # it's not an error
+            unless err.kind_of?(::SourcesApiClient::ApiError) && err.code == 404
+              metrics&.record_error(:event_sync)
+              logger.error("Event sync: #{err.message}\n#{err.backtrace.join("\n")}")
+            end
           end
         end
       ensure


### PR DESCRIPTION
404 error can be caused by cascade delete of Source, when Application.destroy is processed and Source doesn't exist.
It's not an error of sync worker so it should be skipped without logs and metrics update

---

[RHCLOUD-12782](https://issues.redhat.com/browse/RHCLOUD-12782)